### PR TITLE
Fix package dependencies

### DIFF
--- a/ssh-tunnels.el
+++ b/ssh-tunnels.el
@@ -2,7 +2,7 @@
 
 ;; Author: death <github.com/death>
 ;; Version: 1.0
-;; Package-Requires: ((cl-lib "1.0") (tabulated-list "1.0"))
+;; Package-Requires: ((cl-lib "0.5") (emacs "24"))
 ;; Keywords: tools, convenience
 ;; URL: http://github.com/death/ssh-tunnels
 


### PR DESCRIPTION
- `tabulated-list` is not an installable package, but it is present in Emacs 24
- The `cl-lib` bundled in Emacs 24 is marked as 1.0, but the standalone package is 0.5

(In connection with https://github.com/milkypostman/melpa/pull/2295)
