### PR TITLE
Add auto-ssh-tunnels-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ This package lets you run and kill SSH tunnels.  To use it:
 - You may want to temporarily change a tunnel's local port.  To do
   that you may provide a prefix argument to the run command, for
   example by typing `C-u 1235 r`
+  
+## Auto-ssh-tunnels-mode
+
+This package also includes a global minor-mode that automatically
+starts SSH tunnels when Emacs's built-in `open-network-stream`
+function is used.  This mode checks whether a new connection is to
+localhost and to a port for which `ssh-tunnels-configurations` has a
+tunnel with a matching local port, and if so, makes sure that the
+tunnel is running.
+
+Use `M-x auto-ssh-tunnels-mode` to enable this global minor-mode.
 
 # License
 


### PR DESCRIPTION
* `ssh-tunnels.el`: Require netrc for `netrc-port-equal`.
(`open-network-stream@run-ssh-tunnel`): New function that checks whether a connection is to localhost and to a port for which there is a tunnel with a match local port and, if so, ensures that the tunnel is running.
(`auto-ssh-tunnels-mode`): New global minor-mode that advises the `open-network-stream` function with the new function.

---

Thank you for ssh-tunnels! I have been using it with this change for several months along with rcirc to tunnel to a host that runs my IRC bouncer.  Is this a feature that you would be willing to include in ssh-tunnels?