### PR TITLE
Added option to forward UNIX sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,19 @@ This package lets you run and kill SSH tunnels.  To use it:
 
 ```emacs-lisp
 (setq ssh-tunnels-configurations
-      '((:name "my tunnel"
+      '((:name "my local tunnel"
          :local-port 1234
          :remote-port 3306
+         :login "me@host")
+        (:name "my remote tunnel"
+         :type "-R"
+         :local-port 1234
+         :remote-port 3306
+         :login "me@host")
+        (:name "my local socket tunnel"
+         :type "-L"
+         :local-socket "/tmp/socket"
+         :remote-socket "/tmp/socket"
          :login "me@host")))
 ```
 

--- a/helm-ssh-tunnels.el
+++ b/helm-ssh-tunnels.el
@@ -56,22 +56,13 @@
 (require 'ssh-tunnels)
 
 (defun helm-ssh-tunnels--format-tunnel (tunnel)
-  (when (and (ssh-tunnels--property tunnel :local-port)
-	     (ssh-tunnels--property tunnel :local-socket))
-    (error "Tunnel '%s' has both a `:local-port' and a `:local-socket'"
-	   (ssh-tunnels--property tunnel :name)))
-  (format "%s %-20s %-30s %-34s"
+  (ssh-tunnels--validate tunnel)
+  (format "%s %-20s %-30s %-4s %-34s"
           (if (ssh-tunnels--check tunnel) "R" " ")
           (ssh-tunnels--pretty-name (ssh-tunnels--property tunnel :name))
           (ssh-tunnels--property tunnel :login)
-          (format "%s:%s:%s"
-                  (if (ssh-tunnels--forwards-port-p tunnel)
-		      (ssh-tunnels--property tunnel :local-port)
-		    (ssh-tunnels--property tunnel :local-socket))
-                  (ssh-tunnels--property tunnel :host)
-		  (if (ssh-tunnels--forwards-port-p tunnel)
-		      (ssh-tunnels--property tunnel :remote-port)
-		    (ssh-tunnels--property tunnel :remote-socket)))))
+          (ssh-tunnels--property tunnel :type)
+          (ssh-tunnels--forward-definition tunnel)))
 
 (defun helm-ssh-tunnels--get-candidates ()
   (cl-loop for tunnel in ssh-tunnels-configurations

--- a/helm-ssh-tunnels.el
+++ b/helm-ssh-tunnels.el
@@ -61,9 +61,13 @@
           (ssh-tunnels--pretty-name (ssh-tunnels--property tunnel :name))
           (ssh-tunnels--property tunnel :login)
           (format "%s:%s:%s"
-                  (ssh-tunnels--property tunnel :local-port)
+                  (if (ssh-tunnels--forwards-port-p tunnel)
+		      (ssh-tunnels--property tunnel :local-port)
+		    (ssh-tunnels--property tunnel :local-socket))
                   (ssh-tunnels--property tunnel :host)
-                  (ssh-tunnels--property tunnel :remote-port))))
+		  (if (ssh-tunnels--forwards-port-p tunnel)
+		      (ssh-tunnels--property tunnel :remote-port)
+		    (ssh-tunnels--property tunnel :remote-socket)))))
 
 (defun helm-ssh-tunnels--get-candidates ()
   (cl-loop for tunnel in ssh-tunnels-configurations

--- a/helm-ssh-tunnels.el
+++ b/helm-ssh-tunnels.el
@@ -56,6 +56,10 @@
 (require 'ssh-tunnels)
 
 (defun helm-ssh-tunnels--format-tunnel (tunnel)
+  (when (and (ssh-tunnels--property tunnel :local-port)
+	     (ssh-tunnels--property tunnel :local-socket))
+    (error "Tunnel '%s' has both a `:local-port' and a `:local-socket'"
+	   (ssh-tunnels--property tunnel :name)))
   (format "%s %-20s %-30s %-34s"
           (if (ssh-tunnels--check tunnel) "R" " ")
           (ssh-tunnels--pretty-name (ssh-tunnels--property tunnel :name))

--- a/helm-ssh-tunnels.el
+++ b/helm-ssh-tunnels.el
@@ -60,7 +60,7 @@
           (if (ssh-tunnels--check tunnel) "R" " ")
           (ssh-tunnels--pretty-name (ssh-tunnels--property tunnel :name))
           (ssh-tunnels--property tunnel :login)
-          (format "%d:%s:%d"
+          (format "%s:%s:%s"
                   (ssh-tunnels--property tunnel :local-port)
                   (ssh-tunnels--property tunnel :host)
                   (ssh-tunnels--property tunnel :remote-port))))

--- a/ssh-tunnels.el
+++ b/ssh-tunnels.el
@@ -394,24 +394,32 @@ or socket associated with the tunnel.")
 	      (format "[%s]" host)
             host)))
     (cond ((string= tunnel-type "-D")
-           (unless (numberp local-port)
-             (error "No local port specified for tunnel '%s'" name))
-           (format "%s:%s" host local-port))
-          ((string= tunnel-type "-R")
-           (if (and remote-socket local-socket)
-               (format "%s:%s" remote-socket local-socket)
-             (format "%s:%s:%s"
-                     (or remote-port remote-socket)
-                     host
-                     (or local-port local-socket))))
-          (t
-           ;; Default Local port forwarding
-           (if (and local-socket remote-socket)
-               (format "%s:%s" local-socket remote-socket)
-             (format "%s:%s:%s"
-                     (or local-port local-socket)
-                     host
-                     (or remote-port remote-socket)))))))
+	   (unless (numberp local-port)
+	     (error "No local port specified for tunnel '%s'" name))
+	   (format "%s:%s" host local-port))
+	  ((string= tunnel-type "-R")
+	   (cond
+	    ((and remote-port local-port)
+	     (format "%s:%s:%s" remote-port host local-port))
+	    ((and remote-port local-socket)
+	     (format "%s:%s:%s" host remote-port local-socket))
+	    ((and remote-socket local-socket)
+	     (format "%s:%s" remote-socket local-socket))
+	    ((and remote-socket local-port)
+	     (format "%s:%s:%s" remote-socket host local-port))
+	    (t (error "Tunnel '%s' should not have passed the check" name))))
+	  (t
+	   ;; Default Local port forwarding
+	   (cond
+	    ((and local-port remote-socket)
+	     (format "%s:%s:%s" host local-port remote-socket))
+	    ((and local-socket remote-port)
+	     (format "%s:%s:%s" local-socket host remote-port))
+	    ((and local-port remote-port)
+	     (format "%s:%s:%s" local-port host remote-port))
+	    ((and local-socket remote-socket)
+	     (format "%s:%s" local-socket remote-socket))
+	    (t (error "Tunnel '%s' should not have passed the check" name)))))))
 
 ;;; completing-read frontend
 

--- a/ssh-tunnels.el
+++ b/ssh-tunnels.el
@@ -264,7 +264,7 @@ or socket associated with the tunnel.")
     (when (numberp arg)
       ;; Use an ad-hoc local port instead of the local port or socket
       ;; specified in configuration.
-      (setf tunnel (copy-list tunnel))
+      (setf tunnel (cl-copy-list tunnel))
       (cl-remf tunnel :local-port)
       (cl-remf tunnel :local-socket)
       (setf tunnel (cl-list* :local-port arg tunnel)))

--- a/ssh-tunnels.el
+++ b/ssh-tunnels.el
@@ -309,9 +309,9 @@ or socket associated with the tunnel.")
                  (and (null (cl-getf tunnel :local-socket))
                       (cl-getf tunnel :remote-port))))))
         ((eq key :remote-port)
-         (or (cl-getf tunnel :remote-port)
-             (and (null (cl-getf tunnel :remote-socket))
-                  (cl-getf tunnel :local-port))))
+         (and (null (cl-getf tunnel :remote-socket))
+	      (or (cl-getf tunnel :remote-port)
+		  (cl-getf tunnel :local-port))))
         ((eq key :local-socket)
          (let ((state (gethash (cl-getf tunnel :name) ssh-tunnels--state-table)))
            (if (stringp state)
@@ -320,9 +320,9 @@ or socket associated with the tunnel.")
                  (and (null (cl-getf tunnel :local-port))
                       (cl-getf tunnel :remote-socket))))))
         ((eq key :remote-socket)
-         (or (cl-getf tunnel :remote-socket)
-             (and (null (cl-getf tunnel :local-port))
-                  (cl-getf tunnel :local-socket))))
+	 (and (null (cl-getf tunnel :remote-port))
+	      (or (cl-getf tunnel :remote-socket)
+		  (cl-getf tunnel :local-socket))))
         (t
          (cl-getf tunnel key))))
 
@@ -399,27 +399,27 @@ or socket associated with the tunnel.")
 	   (format "%s:%s" host local-port))
 	  ((string= tunnel-type "-R")
 	   (cond
-	    ((and remote-port local-port)
-	     (format "%s:%s:%s" remote-port host local-port))
 	    ((and remote-port local-socket)
 	     (format "%s:%s:%s" host remote-port local-socket))
 	    ((and remote-socket local-socket)
 	     (format "%s:%s" remote-socket local-socket))
-	    ((and remote-socket local-port)
-	     (format "%s:%s:%s" remote-socket host local-port))
-	    (t (error "Tunnel '%s' should not have passed the check" name))))
+	    (t (format "%s:%s:%s"
+		       (or remote-port remote-socket)
+		       host
+		       (or local-port local-socket)))))
 	  (t
 	   ;; Default Local port forwarding
 	   (cond
 	    ((and local-port remote-socket)
 	     (format "%s:%s:%s" host local-port remote-socket))
-	    ((and local-socket remote-port)
-	     (format "%s:%s:%s" local-socket host remote-port))
-	    ((and local-port remote-port)
-	     (format "%s:%s:%s" local-port host remote-port))
 	    ((and local-socket remote-socket)
 	     (format "%s:%s" local-socket remote-socket))
-	    (t (error "Tunnel '%s' should not have passed the check" name)))))))
+	    ((and local-socket remote-port)
+	     (format "%s:%s:%s" local-socket host remote-port))
+	    (t (format "%s:%s:%s"
+		       (or local-port local-socket)
+		       host
+		       (or remote-port remote-socket))))))))
 
 ;;; completing-read frontend
 

--- a/ssh-tunnels.el
+++ b/ssh-tunnels.el
@@ -140,9 +140,8 @@ with the following properties:
   :remote-port - The tunnel's remote port; defaults
                  to the value of `:local-port'.
 
-For tunneling sockets, use the properties below. The type of
-forwarding will be decided by checking if `:local-port' can be found
-or not.
+For tunneling sockets, use the properties below, instead of `:local-port' 
+and/or `:local-tunnel'.
 
   :local-socket - The tunnel's local socket; defaults
                 to the value of `:remote-socket'.
@@ -216,6 +215,9 @@ become irrelevant if `ssh-tunnels-configurations' changes.")
 	     (remote-socket (ssh-tunnels--property tunnel :remote-socket))
              (host (ssh-tunnels--property tunnel :host))
              (login (ssh-tunnels--property tunnel :login)))
+	(when (and local-port local-socket)
+	  (error "Tunnel '%s' has both a `:local-port' and a `:local-socket'"
+		 (ssh-tunnels--property tunnel :name)))
         (push (list tunnel
                     (vector (if (ssh-tunnels--check tunnel) "R" " ")
                             (ssh-tunnels--pretty-name name)
@@ -258,6 +260,10 @@ become irrelevant if `ssh-tunnels-configurations' changes.")
   (let ((tunnel (ssh-tunnels--tunnel t)))
     (when (and (numberp arg) (ssh-tunnels--forwards-port-p tunnel))
       (setf tunnel (cl-list* :local-port arg tunnel)))
+    (when (and (ssh-tunnels--property tunnel :local-port)
+	       (ssh-tunnels--property tunnel :local-socket))
+      (error "Tunnel '%s' has both a `:local-port' and a `:local-socket'"
+	     (ssh-tunnels--property tunnel :name)))
     (when (not (ssh-tunnels--check tunnel))
       (message "Tunneling...")
       (ssh-tunnels--run tunnel)


### PR DESCRIPTION
Now `is-socket?` key can be used to specify if the forwarded "ports" are sockets.
Basically now, if the forwarded line is a socket, it doesn't convert the ports to strings, and doesn't write the hostname in the forwarding command. 