### PR TITLE
Throws error when command exits with a error code

### DIFF
--- a/ssh-tunnels.el
+++ b/ssh-tunnels.el
@@ -356,23 +356,30 @@ or socket associated with the tunnel.")
                 (t (error "Unknown ssh-tunnels command '%s'" command))))
          (default-directory ssh-tunnels-temp-directory))
     (with-temp-buffer
-      (let ((output-code (apply 'call-process ssh-tunnels-program nil (list (current-buffer) t) nil
-                                 "-S" (shell-quote-argument name)
-                                 (append args (list login)))))
-        (if (and (eq command :run) (not (eq 0 output-code)))
-            (error
-              "Tunnel '%s' could not be created. Exited with code: %s and message: %s"
-              name output-code (buffer-substring-no-properties (point-min) (point-max))))
-        output-code))))
+      (let ((exit-status
+             (apply 'call-process ssh-tunnels-program nil t nil
+                    "-S" (shell-quote-argument name)
+                    (append args (list login)))))
+        (when (and (eq command :run)
+                   (not (eql 0 exit-status)))
+          (if (numberp exit-status)
+              (error "Tunnel '%s' could not be created: '%s' (exit status %d)"
+                     name
+                     (buffer-substring-no-properties (point-min) (point-max))
+                     exit-status)
+            (error "Tunnel '%s' could not be created: process exited with signal '%s'"
+                   name
+                   exit-status)))
+        exit-status))))
 
 (defun ssh-tunnels--run (tunnel)
   (remhash (ssh-tunnels--property tunnel :name)
            ssh-tunnels--state-table)
+  (ssh-tunnels--command tunnel :run)
   (puthash (ssh-tunnels--property tunnel :name)
            (or (ssh-tunnels--property tunnel :local-port)
                (ssh-tunnels--property tunnel :local-socket))
-           ssh-tunnels--state-table)
-  (ssh-tunnels--command tunnel :run))
+           ssh-tunnels--state-table))
 
 (defun ssh-tunnels--kill (tunnel)
   (ssh-tunnels--command tunnel :kill)


### PR DESCRIPTION
A tunnel name, along with error code and message are part of the
thrown error.