### PR TITLE
README.md: add symbol usage to examples (see #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package lets you run and kill SSH tunnels.  To use it:
 
 ```emacs-lisp
 (setq ssh-tunnels-configurations
-      '((:name "my local tunnel"
+      `((:name ,(concat "my local tunnel to " system-name)
          :local-port 1234
          :remote-port 3306
          :login "me@host")


### PR DESCRIPTION
I was also looking for the same as requested on #19.
Adding an example to docs would have been useful.